### PR TITLE
Fix for web server deadlocks

### DIFF
--- a/microprofile.h
+++ b/microprofile.h
@@ -3023,6 +3023,7 @@ void MicroProfileWebServerCloseSocket(MpSocket Connection)
 #ifdef _WIN32
 	closesocket(Connection);
 #else
+	shutdown(Connection,SHUT_RDWR);
 	close(Connection);
 #endif
 }


### PR DESCRIPTION
1. It's definitely a deadlock during web server thread shutdown.
   
   Consider this use case: app starts with microprofile enabled, on first flip microprofile will launch web server thread and during app lifetime everythins is ok as accept() will wait for connection but when you call MicroProfileShutdown() it'll try to close web server socket and wait until web server thread will finish its execution. The problem is that thread execution won't be finished because accept() will never return.
2. It seems that there's an assumption that accept() will release its block if you close web server socket.
   
   I'm not sure about it but my guess is that close() call may not close the connection itself, it's just closing only descriptor. Probably on OSX and Windows the implementation itself is safer but proper way to close socket is to call shutdown() + close() if you really want to close connection as well as descriptor.
